### PR TITLE
QRS- 41, Fix records access by dataset name and Zoom view delay

### DIFF
--- a/next/src/modules/dashboardPage/pages/DashboardPage.tsx
+++ b/next/src/modules/dashboardPage/pages/DashboardPage.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { useSession } from 'next-auth/react';
 import QueueAnim from 'rc-queue-anim';
 import React, { useCallback, useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
 import styled from 'styled-components';
 
 import { useTheme } from '@/app/contexts/ThemeProvider';
@@ -236,6 +237,7 @@ const DashboardPage = () => {
           unCheckedChildren="Zoom Mode OFF"
           checked={zoomMode}
           onChange={handleClickZoomMode}
+          disabled={isFetching}
         />
       </SwitchWrapper>
 
@@ -249,6 +251,26 @@ const DashboardPage = () => {
           addFeedback={addFeedback}
         />
       )}
+
+      {!selectedChartData &&
+        zoomMode &&
+        createPortal(
+          <ZoomModeLoadingWrapper>
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: 12,
+              }}
+            >
+              <Spin size="large" />
+              <Typography.Text>Loading chart data...</Typography.Text>
+            </div>
+          </ZoomModeLoadingWrapper>,
+          document.body,
+        )}
 
       {loading && (
         <StateWrapper>
@@ -303,6 +325,18 @@ const DashboardPage = () => {
 };
 
 export default DashboardPage;
+
+const ZoomModeLoadingWrapper = styled.div`
+  background-color: #00000080;
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 50;
+  width: 100%;
+  height: 100%;
+  display: grid;
+  place-items: center;
+`;
 
 const StateWrapper = styled.div`
   display: flex;

--- a/next/src/modules/dashboardPage/pages/DashboardPage.tsx
+++ b/next/src/modules/dashboardPage/pages/DashboardPage.tsx
@@ -21,7 +21,7 @@ import { Filter, SelectedChartData } from '@/types/common';
 
 const DashboardPage = () => {
   const router = useRouter();
-  const { datasetName } = router.query;
+  const { datasetName } = router.query as { datasetName: string };
 
   const { isDarkMode } = useTheme();
   const [recordsToDisplay, setRecordsToDisplay] = useState<Record[]>([]);
@@ -43,7 +43,7 @@ const DashboardPage = () => {
   const fetchAndUpdateHistoryData = async () => {
     setIsFetching(true);
     try {
-      const response = await fetchRecords(filters);
+      const response = await fetchRecords(datasetName, filters);
 
       setRecordsToDisplay((prev) => {
         const uniqIds = new Set<string>();
@@ -77,7 +77,11 @@ const DashboardPage = () => {
   ) => {
     setIsFetching(true);
     try {
-      const response = await fetchRecords(paramFilters ?? filters, limit);
+      const response = await fetchRecords(
+        datasetName,
+        paramFilters ?? filters,
+        limit,
+      );
 
       setRecordsToDisplay(response.data);
       if (response.total > recordsToDisplay.length + 5) {
@@ -272,8 +276,9 @@ const DashboardPage = () => {
           },
         ]}
       >
-        {recordsToDisplay
-          ? recordsToDisplay.map((record, i) => (
+        {recordsToDisplay && !!recordsToDisplay.length ? (
+          <>
+            {recordsToDisplay.map((record, i) => (
               <MainChart
                 key={record.index}
                 isFirst={i === 0}
@@ -284,12 +289,15 @@ const DashboardPage = () => {
                 addFeedback={addFeedback}
                 onClickChart={handleOpenModal}
               />
-            ))
-          : null}
+            ))}
+            <Button disabled={!hasNextPage} onClick={fetchNextPage}>
+              Load More
+            </Button>
+          </>
+        ) : (
+          <Typography.Text type="secondary">No records found</Typography.Text>
+        )}
       </QueueAnim>
-      <Button disabled={!hasNextPage} onClick={fetchNextPage}>
-        Load More
-      </Button>
     </Layout>
   );
 };

--- a/next/src/pages/api/records/list.ts
+++ b/next/src/pages/api/records/list.ts
@@ -15,6 +15,7 @@ router.get(async (req, res) => {
   if (!session) {
     return res.status(401).json({ error: 'Unauthorized User' });
   }
+  const datasetName = req.query.datasetName as string;
   const limit = Number(req.query.limit) || 10;
   const exams = req.query['exams[]'];
   const examIds = Array.isArray(exams) ? exams : [exams];
@@ -24,7 +25,8 @@ router.get(async (req, res) => {
   const query = recordsRepo
     .createQueryBuilder('record')
     .leftJoinAndSelect('record.dataChecks', 'dataCheck')
-    .where(
+    .where('record.dataset_name = :datasetName', { datasetName })
+    .andWhere(
       (qb) => {
         const subQuery = qb
           .subQuery()

--- a/next/src/services/reactQueryFn.ts
+++ b/next/src/services/reactQueryFn.ts
@@ -28,12 +28,14 @@ export const getFragment = async (
 };
 
 export const fetchRecords = async (
+  datasetName: string,
   filters: Filter,
   limit = 5,
 ): Promise<RecordsResponse> => {
   const { exams } = filters;
   const response = await axios.get('/api/records/list', {
     params: {
+      datasetName,
       exams,
       limit,
     },


### PR DESCRIPTION
Fixed access to data by dataset name on the dashboard page.
I added a loading indicator. When switching to Zoom view, we wait for a response from the API /data endpoint. Sometimes this takes longer if we haven't finished loading the other charts