### PR TITLE
QRS-45: Python API: serve MIDI dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ docker-compose up
 2. Run the command `docker-compose up`.
 3. Open `http://localhost:3000/` in your browser
 4. Register a new user.
-5.  Use pgAdmin or another similar tool, and in the 'users' table, set the value of the 'role' field to 'admin'. Raw query: `UPDATE users SET role='admin'::users_role_enum WHERE email='user@email.com';`
+5. In the 'users' table, set the value of the 'role' field to 'admin'. Query: `UPDATE users SET role='admin'::users_role_enum WHERE email='user@email.com';`
 6. Refresh the page.
 7. Navigate to the admin page.
 

--- a/data-api/app/config.py
+++ b/data-api/app/config.py
@@ -2,6 +2,7 @@ import os
 
 RECORDS_TABLE = "records"
 
+HF_TOKEN = os.getenv("HF_TOKEN")
 PG_DSN = os.getenv("DATABASE_URL")
 DATASET_NAME = os.getenv("DATASET_NAME", "roszcz/qrs-swipe-demo")
 DATA_PROBLEM = os.getenv("DATA_PROBLEM", "ecg_classification")

--- a/data-api/app/config.py
+++ b/data-api/app/config.py
@@ -4,3 +4,4 @@ RECORDS_TABLE = "records"
 
 PG_DSN = os.getenv("DATABASE_URL")
 DATASET_NAME = os.getenv("DATASET_NAME", "roszcz/qrs-swipe-demo")
+DATA_PROBLEM = os.getenv("DATA_PROBLEM", "ecg_classification")

--- a/data-api/app/main.py
+++ b/data-api/app/main.py
@@ -40,6 +40,7 @@ async def record(record_id: int):
     r = dataset[record_id]
     return r
 
+
 @app.get("/midi_file/{record_id}")
 async def download_midi(record_id: int):
     piece = ff.MidiPiece.from_huggingface(dataset[record_id])
@@ -49,7 +50,7 @@ async def download_midi(record_id: int):
     # Write the MIDI data to a BytesIO buffer
     buffer = io.BytesIO()
     midi.write(buffer)
-    buffer.seek(0) 
+    buffer.seek(0)
     return StreamingResponse(buffer, media_type="audio/midi", headers={"Content-Disposition": "attachment;filename=output.midi"})
 
 

--- a/data-api/app/main.py
+++ b/data-api/app/main.py
@@ -1,4 +1,7 @@
+import io
+import fortepyan as ff
 from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
 from fastapi.middleware.cors import CORSMiddleware
 
 from app import config as C
@@ -19,7 +22,8 @@ app.add_middleware(
 )
 
 
-dataset = app_utils.prepare_database(C.DATASET_NAME)
+# dataset = app_utils.prepare_database(C.DATASET_NAME)
+dataset = app_utils.get()
 
 
 @app.get("/ping")
@@ -31,6 +35,16 @@ async def ping():
 async def record(record_id: int):
     r = dataset[record_id]
     return r
+
+@app.get("/midi_file")
+async def download_midi():
+    piece = ff.MidiPiece.from_huggingface(dataset[3])
+    midi = piece.to_midi()
+    # Write the MIDI data to a BytesIO buffer
+    buffer = io.BytesIO()
+    midi.write(buffer)
+    buffer.seek(0) 
+    return StreamingResponse(buffer, media_type="audio/midi", headers={"Content-Disposition": "attachment;filename=output.midi"})
 
 
 @app.get("/data")

--- a/data-api/app/utils.py
+++ b/data-api/app/utils.py
@@ -12,11 +12,11 @@ def prepare_midi_review(dataset_name: str) -> Dataset:
         res = c.execute(query, {"name": dataset_name})
         dataset_present = res.scalar()
 
+    dataset = load_dataset(dataset_name, split="train", use_auth_token=C.HF_TOKEN)
     if dataset_present:
         print("Dataset already ingested", dataset_name)
     else:
         print("Ingesting dataset", dataset_name)
-        dataset = load_dataset(dataset_name, split="train", use_auth_token=C.HF_TOKEN)
         # This is the fastest way I now to add a column to hf dataset
         # It's not pretty
         metadata = [{

--- a/data-api/app/utils.py
+++ b/data-api/app/utils.py
@@ -5,6 +5,11 @@ from datasets import load_dataset, Dataset, concatenate_datasets
 from app import config as C
 
 
+def get():
+    dataset = load_dataset("roszcz/giant-midi-sustain", split="train")
+    return dataset
+
+
 def prepare_database(dataset_name: str) -> Dataset:
     token = os.getenv("HF_TOKEN")
     dataset = load_dataset(dataset_name, split="train", use_auth_token=token)

--- a/data-api/requirements.txt
+++ b/data-api/requirements.txt
@@ -4,3 +4,4 @@ datasets==2.13.1
 psycopg2==2.9.6
 SQLAlchemy==2.0.17
 ipython==8.14.0
+fortepyan==0.2.4

--- a/next/src/modules/dashboard/components/midi/MidiPlayer.tsx
+++ b/next/src/modules/dashboard/components/midi/MidiPlayer.tsx
@@ -70,7 +70,7 @@ export default function MidiPlayer() {
       {/* "https://cdn.jsdelivr.net/gh/cifkao/html-midi-player@2b12128/jazz.mid" */}
       <PlayerWrapper color={theme}>
         <midi-player
-          src="https://cdn.jsdelivr.net/gh/cifkao/html-midi-player@2b12128/jazz.mid"
+          src="http://0.0.0.0:8080/midi_file"
           sound-font="https://storage.googleapis.com/magentadata/js/soundfonts/sgm_plus"
           ref={playerRef}
         />
@@ -79,7 +79,7 @@ export default function MidiPlayer() {
         <midi-visualizer
           ref={visualizerRef}
           type="piano-roll"
-          src="https://cdn.jsdelivr.net/gh/cifkao/html-midi-player@2b12128/jazz.mid"
+          src="http://0.0.0.0:8080/midi_file"
         />
       </VisualizerWrapper>
     </section>

--- a/next/src/modules/dashboard/components/midi/MidiPlayer.tsx
+++ b/next/src/modules/dashboard/components/midi/MidiPlayer.tsx
@@ -70,7 +70,7 @@ export default function MidiPlayer() {
       {/* "https://cdn.jsdelivr.net/gh/cifkao/html-midi-player@2b12128/jazz.mid" */}
       <PlayerWrapper color={theme}>
         <midi-player
-          src="http://0.0.0.0:8080/midi_file"
+          src="http://0.0.0.0:8080/midi_file/110"
           sound-font="https://storage.googleapis.com/magentadata/js/soundfonts/sgm_plus"
           ref={playerRef}
         />
@@ -79,7 +79,7 @@ export default function MidiPlayer() {
         <midi-visualizer
           ref={visualizerRef}
           type="piano-roll"
-          src="http://0.0.0.0:8080/midi_file"
+          src="http://0.0.0.0:8080/midi_file/110"
         />
       </VisualizerWrapper>
     </section>


### PR DESCRIPTION
For the "midi_review" problem, python code is now populating a new table `midi_records` with metadata about available midi files. The column `midi_file_path` has an url to get the MIDI file by doing a

```sh
GET {NEXT_PUBLIC_API_URL}/{midi_file_path}
```

For testing, I hardcoded an url into `MidiPlayer.tsx`.

Envs you need for this to work:

```sh
DATASET_NAME=roszcz/giant-midi-sustain
DATA_PROBLEM=midi_review
```

I think we wanted to re-use the `records` table for midi files as well, but the issue is that the columns are completely different. In ECG classification we have "exam_uid" and "position" (and other, less relevant), and in midi we have "midi_file_path", and "midi_filename". 

So I think we either have to create separate recrods table for every data problem, or store everything about a record in a json column 🤔 

❓ ❓ ❓ [internal monologue notes]
I'm leaning toward unified approach where for every problem we have the same `records` table, where python provides columns `["record_id"::int, "dataset_name"::str, "metadata"::json]`. 

The data to review will be at `/data/{record_id, dataset_name}`, and nothing else will be needed to query it (no "position" or "exam_uid").

The process of introducing new problem into python API will then be only to define how to convert some of the original dataset columns into `metadata`. 
❓ ❓ ❓ 