### PR TITLE
QRS-46, Unify the records table for different data problems

### DIFF
--- a/data-api/app/utils.py
+++ b/data-api/app/utils.py
@@ -29,7 +29,7 @@ def prepare_midi_review(dataset_name: str) -> Dataset:
 
         meta_dataset = Dataset.from_list(metadata)
         types = {"metadata": sa.types.JSON}
-        meta_dataset.to_sql("midi_records", con=engine, index=True, if_exists="append", dtype=types)
+        meta_dataset.to_sql("records", con=engine, index=True, if_exists="append", dtype=types)
 
     return dataset
 

--- a/next/src/lib/orm/data-source.ts
+++ b/next/src/lib/orm/data-source.ts
@@ -1,5 +1,5 @@
-// import * as dotenv from 'dotenv';
-// import * as path from 'path';
+import * as dotenv from 'dotenv';
+import * as path from 'path';
 import { DataSource, ObjectLiteral, ObjectType, Repository } from 'typeorm';
 
 import { DataCheck } from './entity/DataCheck';
@@ -11,9 +11,9 @@ import { Record } from './entity/Record';
 import { User } from './entity/User';
 
 // Don't remove next lines
-// dotenv.config({
-//   path: path.resolve(__dirname, '../../../.env.local'),
-// });
+dotenv.config({
+  path: path.resolve(__dirname, '../../../.env.local'),
+});
 
 export const dataSource = new DataSource({
   type: 'postgres',

--- a/next/src/lib/orm/data-source.ts
+++ b/next/src/lib/orm/data-source.ts
@@ -1,5 +1,5 @@
-import * as dotenv from 'dotenv';
-import * as path from 'path';
+// import * as dotenv from 'dotenv';
+// import * as path from 'path';
 import { DataSource, ObjectLiteral, ObjectType, Repository } from 'typeorm';
 
 import { DataCheck } from './entity/DataCheck';
@@ -11,9 +11,9 @@ import { Record } from './entity/Record';
 import { User } from './entity/User';
 
 // Don't remove next lines
-dotenv.config({
-  path: path.resolve(__dirname, '../../../.env.local'),
-});
+// dotenv.config({
+//   path: path.resolve(__dirname, '../../../.env.local'),
+// });
 
 export const dataSource = new DataSource({
   type: 'postgres',

--- a/next/src/lib/orm/entity/Record.ts
+++ b/next/src/lib/orm/entity/Record.ts
@@ -14,22 +14,16 @@ export class Record {
   id: string;
 
   @Column({ type: 'text' })
-  exam_uid: string;
+  record_id: string;
 
   @Column({ type: 'text', nullable: true })
   dataset_name: string;
 
-  @Column({ type: 'int' })
-  position: number;
+  @Column({ type: 'json' })
+  metadata: any;
 
-  @Column({ type: 'text' })
-  label: string;
-
-  @Column({ type: 'int' })
-  index: number;
-
-  @CreateDateColumn({ type: 'timestamp', name: 'time' })
-  time: Date;
+  @CreateDateColumn({ type: 'timestamp', name: 'created_at' })
+  created_at: Date;
 
   @OneToMany(() => DataCheck, (dataCheck) => dataCheck.record)
   dataChecks: DataCheck[];

--- a/next/src/lib/orm/migration/1693233420723-UpdateRecordsTable.ts
+++ b/next/src/lib/orm/migration/1693233420723-UpdateRecordsTable.ts
@@ -1,0 +1,81 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UpdateRecordsTable1693233420723 implements MigrationInterface {
+  name = 'UpdateRecordsTable1693233420723';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            DELETE FROM "records"
+        `);
+    await queryRunner.query(`
+            DELETE FROM "data_checks"
+        `);
+
+    await queryRunner.query(`
+            ALTER TABLE "records" DROP COLUMN "exam_uid"
+        `);
+    await queryRunner.query(`
+            ALTER TABLE "records" DROP COLUMN "position"
+        `);
+    await queryRunner.query(`
+            ALTER TABLE "records" DROP COLUMN "label"
+        `);
+    await queryRunner.query(`
+            ALTER TABLE "records" DROP COLUMN "index"
+        `);
+    await queryRunner.query(`
+            ALTER TABLE "records" DROP COLUMN "time"
+        `);
+    await queryRunner.query(`
+            ALTER TABLE "records"
+            ADD "record_id" text NOT NULL
+        `);
+    await queryRunner.query(`
+            ALTER TABLE "records"
+            ADD "metadata" json NOT NULL
+        `);
+    await queryRunner.query(`
+            ALTER TABLE "records"
+            ADD "created_at" TIMESTAMP NOT NULL DEFAULT now()
+        `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            DELETE FROM "records"
+        `);
+    await queryRunner.query(`
+            DELETE FROM "data_checks"
+        `);
+
+    await queryRunner.query(`
+            ALTER TABLE "records" DROP COLUMN "created_at"
+        `);
+    await queryRunner.query(`
+            ALTER TABLE "records" DROP COLUMN "metadata"
+        `);
+    await queryRunner.query(`
+            ALTER TABLE "records" DROP COLUMN "record_id"
+        `);
+    await queryRunner.query(`
+            ALTER TABLE "records"
+            ADD "time" TIMESTAMP NOT NULL DEFAULT now()
+        `);
+    await queryRunner.query(`
+            ALTER TABLE "records"
+            ADD "index" integer NOT NULL
+        `);
+    await queryRunner.query(`
+            ALTER TABLE "records"
+            ADD "label" text NOT NULL
+        `);
+    await queryRunner.query(`
+            ALTER TABLE "records"
+            ADD "position" integer NOT NULL
+        `);
+    await queryRunner.query(`
+            ALTER TABLE "records"
+            ADD "exam_uid" text NOT NULL
+        `);
+  }
+}


### PR DESCRIPTION
@roszcz I've added a DB update [Ticket](https://sacrebleu.atlassian.net/jira/software/projects/QRS/boards/6?selectedIssue=QRS-46) . The new migration will DELETE ALL data from the database for both 'record' and 'data_check(feedback)' tables.
I encountered an issue where Python is not populating the table for 'midi'.
Will you have time to Check?